### PR TITLE
jdk8 compat

### DIFF
--- a/play-maven-plugin/src/main/java/com/google/code/play/AbstractPlayServerMojo.java
+++ b/play-maven-plugin/src/main/java/com/google/code/play/AbstractPlayServerMojo.java
@@ -33,6 +33,7 @@ import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.taskdefs.Java;
 import org.apache.tools.ant.types.Path;
+import org.apache.tools.ant.util.JavaEnvUtils;
 
 /**
  * Base class for Play&#33; server mojos.
@@ -140,7 +141,13 @@ public abstract class AbstractPlayServerMojo
             }
 
             // JDK 7 compat
-            javaTask.createJvmarg().setValue( "-XX:-UseSplitVerifier" );
+            if (JavaEnvUtils.isJavaVersion(JavaEnvUtils.JAVA_1_7)) {
+                javaTask.createJvmarg().setValue( "-XX:-UseSplitVerifier" );
+            }
+            // JDK 8 compat
+            if (JavaEnvUtils.isAtLeastJavaVersion(JavaEnvUtils.JAVA_1_8)) {
+                javaTask.createJvmarg().setValue( "-noverify" );
+            }
 
             String javaPolicy = configParser.getProperty( "java.policy" );
             if ( javaPolicy != null && javaPolicy.length() > 0 )

--- a/play-maven-plugin/src/main/java/com/google/code/play/PlayPrecompileMojo.java
+++ b/play-maven-plugin/src/main/java/com/google/code/play/PlayPrecompileMojo.java
@@ -30,6 +30,7 @@ import org.apache.tools.ant.Project;
 import org.apache.tools.ant.taskdefs.Java;
 import org.apache.tools.ant.types.Path;
 
+import org.apache.tools.ant.util.JavaEnvUtils;
 import org.codehaus.plexus.util.FileUtils;
 
 /**
@@ -162,7 +163,13 @@ public class PlayPrecompileMojo
             }
 
             // JDK 7 compat
-            javaTask.createJvmarg().setValue( "-XX:-UseSplitVerifier" );
+            if (JavaEnvUtils.isJavaVersion(JavaEnvUtils.JAVA_1_7)) {
+                javaTask.createJvmarg().setValue( "-XX:-UseSplitVerifier" );
+            }
+            // JDK 8 compat
+            if (JavaEnvUtils.isAtLeastJavaVersion(JavaEnvUtils.JAVA_1_8)) {
+                javaTask.createJvmarg().setValue( "-noverify" );
+            }
         }
         else
         {


### PR DESCRIPTION
Hi,

It seems that *UseSplitVerifier* has no more available with JDK8.
What do you think to add **-noverify** for JDK 8 ?

Feel fre to reject/accept/modify this PR.

Regards,
Neoh

PS: I had the following error in test mode if tmp/classes/**.class files major version was 52 (Java8).
```
An unexpected error occured caused by exception VerifyError:
Expecting a stackmap frame at branch target 29 Exception Details: Location: controllers/TestRunner.cacheEntry(Ljava/lang/String;)V @7: ifne Reason: Expected stackmap frame at this location.
```
